### PR TITLE
Adds longjs as a dependency to bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "threejs": "r72",
     "extjs": "~5.0.x",
     "protobuf": "5.0.1",
+    "long": "3.2.0",
     "smoothie": "*",
     "jpgjs": "notmasteryet/jpgjs",
     "numericjs": "~1.2.6",


### PR DESCRIPTION
Forces version to 3.2.0. Newer versions seem to be broken